### PR TITLE
gazebo: propagate the Link device period to the LinkExport data structure

### DIFF
--- a/models/orogen/rock_gazebo.rb
+++ b/models/orogen/rock_gazebo.rb
@@ -78,12 +78,14 @@ class OroGen::RockGazebo::ModelTask
                     model_transform = self.class.find_transform_of_port(task_port)
                     raise ArgumentError, "you did not select the frames for #{model_transform.from} or #{model_transform.to}, needed for #{srv.name}"
                 end
+                device = find_device_attached_to(srv)
                 exports << Types.rock_gazebo.LinkExport.new(
                     port_name: task_port.name,
                     source_link: transform.from,
                     target_link: transform.to,
                     source_frame: transform.from,
-                    target_frame: transform.to)
+                    target_frame: transform.to,
+                    port_period: Time.at(device.period))
             else
                 raise ArgumentError, "cannot find the transform information for #{task_port}"
             end

--- a/test/orogen/test_rock_gazebo.rb
+++ b/test/orogen/test_rock_gazebo.rb
@@ -17,8 +17,14 @@ module OroGen
                 model = ModelTask.specialize
                 model.require_dynamic_service 'link_export', as: "test",
                     port_name: 'src2tgt'
+                robot_model = Syskit::Robot::RobotDefinition.new
+                test_link_dev = robot_model.device Rock::Devices::Gazebo::Link, as: 'test'
+                test_link_dev.period(0.5)
 
-                model_with_frames = model.use_frames('test_source' => 'src_frame', 'test_target' => 'tgt_frame')
+                model_with_frames = model.
+                    use_frames('test_source' => 'src_frame', 'test_target' => 'tgt_frame').
+                    with_arguments('test_dev' => test_link_dev).
+                    transformer { frames 'src_frame', 'tgt_frame' }
                 task = syskit_stub_deploy_and_configure(model_with_frames)
                 
                 exports = task.orocos_task.exported_links
@@ -30,6 +36,7 @@ module OroGen
                 assert_equal "tgt_frame", export.target_frame
                 assert_equal "src_frame", export.source_link
                 assert_equal "tgt_frame", export.target_link
+                assert_equal 0.5, export.port_period.to_f
             end
         end
     end


### PR DESCRIPTION
Depends on https://github.com/Brazilian-Institute-of-Robotics/simulation-orogen-rock_gazebo/pull/32