### PR TITLE
fix RockGazebo test when loading under a fully configured robot

### DIFF
--- a/test/orogen/test_rock_gazebo.rb
+++ b/test/orogen/test_rock_gazebo.rb
@@ -34,7 +34,7 @@ module OroGen
                 model.require_dynamic_service 'link_export', as: "test",
                     port_name: 'src2tgt'
                 robot_model = Syskit::Robot::RobotDefinition.new
-                test_link_dev = robot_model.device Rock::Devices::Gazebo::Link, as: 'test'
+                test_link_dev = robot_model.device Rock::Devices::Gazebo::Link, as: 'test', using: model
                 test_link_dev.period(0.5)
 
                 model_with_frames = model.
@@ -60,7 +60,7 @@ module OroGen
                 model.require_dynamic_service 'link_export', as: "test",
                     port_name: 'src2tgt'
                 robot_model = Syskit::Robot::RobotDefinition.new
-                test_link_dev = robot_model.device Rock::Devices::Gazebo::Link, as: 'test'
+                test_link_dev = robot_model.device Rock::Devices::Gazebo::Link, as: 'test', using: model
 
                 model_with_frames = model.
                     use_frames('test_source' => 'src_frame', 'test_target' => 'tgt_frame').


### PR DESCRIPTION
In this case, there are drivers that match the gazebo devices, and
we therefore need to explicitely give the stub driver