### PR TITLE
get the pose predicates from the cucumber bundles

### DIFF
--- a/models/compositions/maintain_pose.rb
+++ b/models/compositions/maintain_pose.rb
@@ -1,0 +1,41 @@
+require 'rock/models/compositions/pose_predicate'
+
+module Rock
+    module Compositions
+        # Composition that verifies whether a certain pose is reached within a
+        # given timeout
+        class MaintainPose < PosePredicate
+            argument :duration
+
+            event :exceeds_tolerance
+            forward :exceeds_tolerance => :failed
+            event :no_samples
+            forward :no_samples => :failed
+
+            script do
+                pose_r = pose_child.pose_samples_port.reader
+
+                poll_until(success_event) do
+                    if duration && (lifetime > duration)
+                        if last_pose
+                            success_event.emit
+                        else
+                            no_samples_event.emit
+                        end
+                    end
+
+                    if sample = pose_r.read_new
+                        @last_pose = Types.base.Pose.new(
+                            position: sample.position,
+                            orientation: sample.orientation)
+                        if !within_tolerance?(sample)
+                            exceeds_tolerance_event.emit(
+                                Hash[expected: rbs_to_hash(self.pose),
+                                     actual: rbs_to_hash(@last_pose)])
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/models/compositions/pose_predicate.rb
+++ b/models/compositions/pose_predicate.rb
@@ -1,0 +1,59 @@
+require 'base/float'
+require 'rock/models/services/pose'
+
+module Rock
+    module Compositions
+        # Base implementation for other compositions that handle pose-related
+        # predicates
+        #
+        # It really does nothing by itself
+        class PosePredicate < Syskit::Composition
+            # The target pose, as a Types.base.Pose object
+            argument :pose
+            # The position tolerance in (x, y, z) as a Eigen::Vector3 object
+            #
+            # Axes that are not to be compared should be set to Base.unset
+            argument :position_tolerance
+
+            # The position tolerance in (y, p, r) as a Eigen::Vector3 object
+            #
+            # Rotations that are not to be compared should be set to Base.unset
+            argument :orientation_tolerance
+
+            # The pose source
+            add Rock::Services::Pose, as: 'pose'
+            
+            # The last received pose as a Types.base.samples.RigidBodyState
+            # object
+            attr_reader :last_pose
+
+            # Whether the given sample is approximately equal to the target
+            # pose
+            def within_tolerance?(sample)
+                diff_position = (pose.position - sample.position)
+                3.times do |i|
+                    next if Base.unset?(position_tolerance[i])
+                    return false if diff_position[i].abs > position_tolerance[i]
+                end
+
+                diff_orientation = pose.orientation.inverse() * sample.orientation;
+                diff_ypr = diff_orientation.to_euler
+                3.times do |i|
+                    next if Base.unset?(orientation_tolerance[i])
+                    return false if diff_ypr[i].abs > orientation_tolerance[i]
+                end
+
+                true
+            end
+
+            def rbs_to_hash(rbs)
+                position    = Hash[[:x, :y, :z].zip(rbs.position.to_a)]
+                orientation = Hash[[:yaw, :pitch, :roll].zip(rbs.orientation.to_euler.to_a)]
+                position.merge(orientation)
+            end
+
+            event :timed_out
+            forward :timed_out => :failed
+        end
+    end
+end

--- a/models/compositions/reach_pose.rb
+++ b/models/compositions/reach_pose.rb
@@ -1,0 +1,36 @@
+require 'rock/models/compositions/pose_predicate'
+
+module Rock
+    module Compositions
+        # Composition that verifies whether a certain pose is reached within a
+        # given timeout
+        class ReachPose < PosePredicate
+            # The timeout
+            argument :timeout
+
+            # The pose that matched the target as a Types.base.Pose object
+            attr_reader :matching_pose
+
+            script do
+                pose_r = pose_child.pose_samples_port.reader(type: :buffer, size: 10)
+
+                poll_until(success_event) do
+                    if sample = pose_r.read_new
+                        @last_pose = sample
+                    end
+
+                    if sample && within_tolerance?(sample)
+                        @matching_pose = Types.base.Pose.new(
+                            position: sample.position,
+                            orientation: sample.orientation)
+                        success_event.emit(matching_pose)
+                    elsif timeout && (lifetime > timeout)
+                        timed_out_event.emit(
+                            Hash[expected: rbs_to_hash(self.pose),
+                                 last_pose: (rbs_to_hash(last_pose) if last_pose)])
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/compositions/test_maintain_pose.rb
+++ b/test/compositions/test_maintain_pose.rb
@@ -1,0 +1,83 @@
+require 'models/compositions/maintain_pose'
+require 'timecop'
+
+module Rock
+    module Compositions
+        describe MaintainPose do
+            attr_reader :pose, :rbs, :maintain_pose
+            before do
+                @pose = Types.base.Pose.new
+                pose.position = Eigen::Vector3.new(1, 2, 3)
+                pose.orientation = Eigen::Quaternion.from_angle_axis(0.1, Eigen::Vector3.UnitX)
+
+                @rbs = Types.base.samples.RigidBodyState.Invalid
+                rbs.position = Eigen::Vector3.Zero
+                rbs.orientation = Eigen::Quaternion.Identity
+
+                @maintain_pose = syskit_stub_and_deploy(
+                    MaintainPose.with_arguments(pose: pose, duration: 10))
+            end
+
+            def assert_pose_in_event_equal(rbs, actual)
+                expected = Hash[x: rbs.position.x, y: rbs.position.y, z: rbs.position.z,
+                                yaw: rbs.orientation.yaw, pitch: rbs.orientation.pitch, roll: rbs.orientation.roll]
+                expected.each_key do |k|
+                    assert_in_delta expected[k], actual[k], 1e-6, "expected and actual values differ on #{k}: #{expected[k]} and #{actual[k]}"
+                end
+            end
+
+
+            it "terminates successfully if the target pose is maintained within the expected duration" do
+                maintain_pose.position_tolerance = Eigen::Vector3.new
+                maintain_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(maintain_pose)
+                flexmock(maintain_pose).should_receive(:within_tolerance?).and_return(true)
+                sample = nil
+                Timecop.freeze do
+                    10.times do
+                        Timecop.travel(1)
+                        maintain_pose.pose_child.orocos_task.pose_samples.
+                            write(sample = Types.base.samples.RigidBodyState.new)
+                        process_events
+                    end
+                end
+                assert_event_emission maintain_pose.success_event
+            end
+
+            it "fails at the end of the period if no samples were ever received" do
+                maintain_pose.position_tolerance = Eigen::Vector3.new
+                maintain_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(maintain_pose)
+                plan.unmark_mission_task(maintain_pose)
+                Timecop.travel(10) do
+                    assert_event_emission(maintain_pose.no_samples_event, garbage_collect_pass: false)
+                end
+            end
+
+            it "ignores the duration if none is provided" do
+                maintain_pose = syskit_stub_and_deploy(
+                    MaintainPose.with_arguments(pose: pose, duration: nil))
+                maintain_pose.position_tolerance = Eigen::Vector3.new
+                maintain_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(maintain_pose)
+                Timecop.travel(10) do
+                    process_events
+                    assert maintain_pose.running?
+                end
+            end
+
+            it "fails if a sample outside tolerance is received" do
+                maintain_pose.position_tolerance = Eigen::Vector3.new
+                maintain_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(maintain_pose)
+                maintain_pose.pose_child.orocos_task.pose_samples.write(rbs)
+                flexmock(maintain_pose).should_receive(:within_tolerance?).and_return(false)
+                plan.unmark_mission_task(maintain_pose)
+
+                event = assert_event_emission(maintain_pose.exceeds_tolerance_event, garbage_collect_pass: false)
+                assert_pose_in_event_equal pose, event.context.first[:expected]
+                assert_pose_in_event_equal rbs, event.context.first[:actual]
+            end
+        end
+    end
+end

--- a/test/compositions/test_pose_predicate.rb
+++ b/test/compositions/test_pose_predicate.rb
@@ -1,0 +1,73 @@
+require 'models/compositions/pose_predicate'
+
+module Rock
+    module Compositions
+        describe PosePredicate do
+            describe "#within_tolerance?" do
+                attr_reader :pose, :sample, :reach_pose
+                before do
+                    @pose = Types.base.Pose.new(
+                        position: Eigen::Vector3.Zero,
+                        orientation: Eigen::Quaternion.Identity)
+                    @sample = Types.base.Pose.new(
+                        position: Eigen::Vector3.new(1, 2, -3),
+                        orientation: Eigen::Quaternion.from_angle_axis(0.1, Eigen::Vector3.UnitZ) *
+                            Eigen::Quaternion.from_angle_axis(0.1, Eigen::Vector3.UnitY) *
+                            Eigen::Quaternion.from_angle_axis(0.1, Eigen::Vector3.UnitX))
+                    @reach_pose = ReachPose.new(pose: pose)
+                end
+                it "returns true if each position's axis is within the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.new(1.1, 2.1, 3.1)
+                    reach_pose.orientation_tolerance = Eigen::Vector3.Unset
+                    assert reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if the X axis is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.new(0.5, 2.1, 3.1)
+                    reach_pose.orientation_tolerance = Eigen::Vector3.Unset
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if the Y axis is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.new(1.1, 0.1, 3.1)
+                    reach_pose.orientation_tolerance = Eigen::Vector3.Unset
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if the Z axis is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.new(1.1, 2.1, 0.1)
+                    reach_pose.orientation_tolerance = Eigen::Vector3.Unset
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "ignores position axis whose tolerance is Base.unset" do
+                    reach_pose.position_tolerance = Eigen::Vector3.new(1.1, Base.unset, 3.1)
+                    reach_pose.orientation_tolerance = Eigen::Vector3.Unset
+                    assert reach_pose.within_tolerance?(sample)
+                end
+
+                it "returns true if each orientation's angles are within the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.Unset
+                    reach_pose.orientation_tolerance = Eigen::Vector3.new(0.2, 0.2, 0.2)
+                    assert reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if yaw is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.Unset
+                    reach_pose.orientation_tolerance = Eigen::Vector3.new(0.05, 0.2, 0.2)
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if pitch is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.Unset
+                    reach_pose.orientation_tolerance = Eigen::Vector3.new(0.2, 0.05, 0.2)
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "returns false if roll is outside the specified tolerance" do
+                    reach_pose.position_tolerance = Eigen::Vector3.Unset
+                    reach_pose.orientation_tolerance = Eigen::Vector3.new(0.2, 0.2, 0.05)
+                    refute reach_pose.within_tolerance?(sample)
+                end
+                it "ignores orientation angles whose tolerance is Base.unset" do
+                    reach_pose.position_tolerance = Eigen::Vector3.Unset
+                    reach_pose.orientation_tolerance = Eigen::Vector3.new(0.2, Base.unset, 0.2)
+                    assert reach_pose.within_tolerance?(sample)
+                end
+            end
+        end
+    end
+end

--- a/test/compositions/test_reach_pose.rb
+++ b/test/compositions/test_reach_pose.rb
@@ -1,0 +1,107 @@
+require 'models/compositions/reach_pose'
+require 'timecop'
+
+module Rock
+    module Compositions
+        describe ReachPose do
+            attr_reader :pose, :rbs, :reach_pose
+            before do
+                @pose = Types.base.Pose.new
+                pose.position = Eigen::Vector3.new(1, 2, 3)
+                pose.orientation = Eigen::Quaternion.from_angle_axis(0.1, Eigen::Vector3.UnitX)
+
+                @rbs = Types.base.samples.RigidBodyState.Invalid
+                rbs.position = Eigen::Vector3.Zero
+                rbs.orientation = Eigen::Quaternion.Identity
+
+                @reach_pose = syskit_stub_and_deploy(
+                    ReachPose.with_arguments(pose: pose, timeout: 10))
+            end
+
+            def assert_times_out
+                plan.unmark_mission_task reach_pose
+                Timecop.travel(10) do
+                    assert_event_emission(reach_pose.timed_out_event, garbage_collect_pass: false)
+                end
+            end
+
+            def assert_pose_in_event_equal(rbs, actual)
+                expected = Hash[x: rbs.position.x, y: rbs.position.y, z: rbs.position.z,
+                                yaw: rbs.orientation.yaw, pitch: rbs.orientation.pitch, roll: rbs.orientation.roll]
+                expected.each_key do |k|
+                    assert_in_delta expected[k], actual[k], 1e-6, "expected and actual values differ on #{k}: #{expected[k]} and #{actual[k]}"
+                end
+            end
+
+            it "terminates successfully if the target is reached" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                reach_pose.pose_child.orocos_task.pose_samples.
+                    write(sample = Types.base.samples.RigidBodyState.new)
+                flexmock(reach_pose).should_receive(:within_tolerance?).and_return(true)
+                event = assert_event_emission reach_pose.success_event
+
+                sample_as_pose = Types.base.Pose.new(position: sample.position, orientation: sample.orientation)
+                assert_equal [sample_as_pose], event.context
+                assert_equal sample_as_pose, reach_pose.matching_pose
+            end
+
+            it "times out if no pose samples arrive" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                flexmock(reach_pose).should_receive(:within_tolerance?).never
+                event = assert_times_out
+                assert_pose_in_event_equal pose, event.context.first[:expected]
+                assert_nil event.context.first[:last_pose]
+            end
+
+            it "times out if no pose samples within tolerance arrive" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                reach_pose.pose_child.orocos_task.pose_samples.write(rbs)
+                flexmock(reach_pose).should_receive(:within_tolerance?).and_return(false)
+                event = assert_times_out
+
+                assert_pose_in_event_equal pose, event.context.first[:expected]
+                assert_pose_in_event_equal rbs, event.context.first[:last_pose]
+            end
+
+            it "does nothing if no pose samples arrive" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                flexmock(reach_pose).should_receive(:within_tolerance?).never
+                process_events
+                assert reach_pose.running?
+            end
+
+            it "does nothing if no pose samples arrive within the tolerance" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                reach_pose.pose_child.orocos_task.pose_samples.
+                    write(Types.base.samples.RigidBodyState.new)
+                flexmock(reach_pose).should_receive(:within_tolerance?).once.and_return(false)
+                process_events
+                assert reach_pose.running?
+            end
+
+            it "emits success if the pose and timeout are reached at the same time" do
+                reach_pose.position_tolerance = Eigen::Vector3.new
+                reach_pose.orientation_tolerance = Eigen::Vector3.new
+                syskit_configure_and_start(reach_pose)
+                reach_pose.pose_child.orocos_task.pose_samples.
+                    write(sample = Types.base.samples.RigidBodyState.new)
+                flexmock(reach_pose).should_receive(:within_tolerance?).and_return(true)
+
+                Timecop.travel(10) do
+                    assert_event_emission reach_pose.success_event
+                end
+                assert !reach_pose.failed_event.emitted?
+            end
+        end
+    end
+end


### PR DESCRIPTION
It seems that it's more useful than just in cucumber ...

Namely, the mission-start wrapper will use it to verify that we do reach the "holding" position and stay there for a little time before starting the actual mission.